### PR TITLE
Change to absolute install path for Go shared lib Mac binary

### DIFF
--- a/AIRSPACE-README.md
+++ b/AIRSPACE-README.md
@@ -3,24 +3,31 @@
 This is a fork of [Google's OR-Tools repo](https://github.com/google/or-tools).
 It has Go bindings and binaries for use with Go projects.
 
-## Install OR-tools for Go (Mac)
+## Install (Mac)
  1. Download binaries for Mac:
-    `https://github.com/AirspaceTechnologies/or-tools/releases/download/v9.9-go1.22.1/or-tools_universal_macOS-12.5.1_go_v9.9.4003.tar.gz`
- 1. Install/extract to rpath:
-    `sudo tar -xf or-tools_universal_macOS-12.5.1_go_v9.9.4003.tar.gz --strip 1 -C /usr/local/lib`
- 1. Export `DYLD_LIBRARY_PATH` if necessary:
-    `export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/usr/local/lib`
+    `https://github.com/AirspaceTechnologies/or-tools/releases/download/v9.9-go1.22.1/or-tools_universal_macOS-14.4.1_go_v9.9.4010.tar.gz`
+ 1. Install/extract to `/usr/local/lib`:
+    `sudo tar -xf or-tools_universal_macOS-14.4.1_go_v9.9.4010.tar.gz --strip 1 -C /usr/local/lib`
  1. Clean module download cache if necessary:
     `go clean --modcache`
 
-## Develop OR-tools for Go (Mac)
+## Install to a Custom Location (Mac)
+ By default, the Mac binary releases embed an absolute install path (`/usr/local/lib`).
+ To install the binaries to a different location:
+ 1. Repeat steps 1 and 2 above, replacing `/usr/local/lib` with custom `/install/path`
+ 1. Set shared library's embedded install path relative to `@rpath`, and add rpath accordingly:
+    `install_name_tool -id @rpath/libgoortools.dylib -add_rpath /install/path /install/path/libgoortools.dylib`
+ 1. Provide linker search path and runtime search path via CGO env var when compiling or running Go tests:
+    `CGO_LDFLAGS='-L/install/path -Wl,-rpath,/install/path'`
+
+## Develop (Mac)
 
 ### Setup
 <details>
   <summary>Required once; expand for steps</summary>
 
   1. Install XCode:
-     `xcode-select install`
+     `xcode-select --install`
   1. Install C++ tools:
      `brew install cmake wget pkg-config`
   1. Install SWIG 4.1.1:
@@ -39,7 +46,7 @@ It has Go bindings and binaries for use with Go projects.
   1. Create universal Mac binaries:
      `sh universal.sh -a [arm64 tar ball] -x [x86_64 tar ball] -o [output tar ball]`
 
-     For example: `sh universal.sh -a export/or-tools_arm64_macOS-12.5.1_go_v9.9.4003.tar.gz -x export/or-tools_x86_64_macOS-12.5.1_go_v9.9.4003.tar.gz -o export/or-tools_universal_macOS-12.5.1_go_v9.9.4003.tar.gz`
+     For example: `sh universal.sh -a export/or-tools_arm64_macOS-14.4.1_go_v9.9.4010.tar.gz -x export/or-tools_x86_64_macOS-14.4.1_go_v9.9.4010.tar.gz -o export/or-tools_universal_macOS-14.4.1_go_v9.9.4010.tar.gz`
   1. For Linux x86_64 (takes ~45 mins, uses Docker to build everything from scratch):
      `sh tools/release/build_delivery_airspace.sh`
   1. Log into Github and create a release with the resulting binaries in the `export` directory

--- a/cmake/go.cmake
+++ b/cmake/go.cmake
@@ -61,7 +61,15 @@ set_target_properties(goortools PROPERTIES
 # note: macOS is APPLE and also UNIX !
 if(APPLE)
   target_link_options(goortools PRIVATE -undefined dynamic_lookup)
-  set_target_properties(goortools PROPERTIES INSTALL_RPATH "@loader_path")
+
+  # Use absolute install path to work around bug with MacOS 14/XCode 15:
+  # https://developer.apple.com/forums/thread/737920?answerId=766944022#766944022
+  set_target_properties(goortools PROPERTIES BUILD_WITH_INSTALL_RPATH FALSE)
+  set_target_properties(goortools PROPERTIES BUILD_WITH_INSTALL_NAME_DIR TRUE)
+  set_target_properties(goortools PROPERTIES SKIP_BUILD_RPATH TRUE)
+  set_target_properties(goortools PROPERTIES INSTALL_NAME_DIR "/usr/local/lib")
+  # set_target_properties(goortools PROPERTIES INSTALL_RPATH "@loader_path")
+
   # Xcode fails to build if library doesn't contains at least one source file.
   if(XCODE)
     file(GENERATE


### PR DESCRIPTION
* To work around Apple/Xcode changing default search path behavior for DYLD
* Update Airspace README